### PR TITLE
Realoca short description para baixo das fotos de produto

### DIFF
--- a/template/pages/@/sections/product-block.ejs
+++ b/template/pages/@/sections/product-block.ejs
@@ -87,7 +87,7 @@ const apx_props = _.cms('apx_props') || {}
           <% } %>
           <!-- Custom additional code on bottom of images gallery -->
           <% if (_.state.short_description) { %>
-            <p class="product__info mt-3 lead">
+            <p class="product__info mt-3 lead short-description">
               <%= _.state.short_description %>
             </p>
           <% } %>

--- a/template/pages/@/sections/product-block.ejs
+++ b/template/pages/@/sections/product-block.ejs
@@ -86,6 +86,11 @@ const apx_props = _.cms('apx_props') || {}
             <% } %>
           <% } %>
           <!-- Custom additional code on bottom of images gallery -->
+          <% if (_.state.short_description) { %>
+            <p class="product__info mt-3 lead">
+              <%= _.state.short_description %>
+            </p>
+          <% } %>
         </div>
 
         <div class="col col-md-4  px-md-5 product--side">
@@ -288,11 +293,7 @@ const apx_props = _.cms('apx_props') || {}
               </div>
             </div>
             
-            <% if (_.state.short_description) { %>
-              <p class="product__info mt-3 lead">
-                <%= _.state.short_description %>
-              </p>
-            <% } %>
+          
           </div>
         </div>
       </div>

--- a/template/scss/custom-css/_styles.scss
+++ b/template/scss/custom-css/_styles.scss
@@ -1710,6 +1710,13 @@ body #storefront-app>div>h1{
     }   
 }
 
+.short-description {
+    font-style: italic;  
+    font-size: 0.875rem; 
+    text-align: center ;
+  }
+  
+
 .discount-applier__coupon-btn{line-height: initial;
     padding: 0.8rem 0;}
 .discount-applier__coupon-btn,


### PR DESCRIPTION
Mudança faz com que as informações de medidas do modelo sejam disponibilizadas abaixo das fotos do produto ( e agora por padrão os produtos deverão ter na short description as medidas do modelo)